### PR TITLE
fix: replace auto changelog with git log for changelog generation

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -107,8 +107,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          # Generate changelog
-          CHANGELOG=$(auto changelog)
+          # Generate a simple changelog based on recent commits
+          CHANGELOG=$(git log --oneline --since="1 week ago" | head -10 | sed 's/^/- /')
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          # Generate changelog
-          CHANGELOG=$(auto changelog)
+          # Generate a simple changelog based on recent commits
+          CHANGELOG=$(git log --oneline --since="1 week ago" | head -10 | sed 's/^/- /')
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Replace auto changelog command with git log approach
- Generate changelog from recent commits (last week)
- Avoid dependency on auto changelog command that was failing
- Use simple git log --oneline format for readability